### PR TITLE
add: 添加一键查询linux信息到内置命令列表

### DIFF
--- a/server/app/config/shell.json
+++ b/server/app/config/shell.json
@@ -33,5 +33,10 @@
     "name": "生成ssh密钥对",
     "command": "ssh-keygen -t rsa -b 2048",
     "description": "生成ssh密钥对"
+  },
+  {
+    "name": "一键查询linux信息",
+    "command": "echo -e \"\\n\\n------ 操作系统类型 ------\" && uname -a || echo \"无法获取操作系统信息\"; echo -e \"\\n------ 发行版本信息 ------\" && command -v lsb_release >/dev/null 2>&1 && lsb_release -a || echo \"无法获取发行版本信息\"; echo -e \"\\n------ 系统详细版本 ------\" && [ -f /etc/os-release ] && cat /etc/os-release || echo \"无法读取 /etc/os-release 文件\"; echo -e \"\\n------ 系统初始进程 ------\" && ps -p 1 -o comm= || echo \"无法获取系统初始进程\"; echo -e \"\\n-------- 内核版本 --------\" && uname -r || echo \"无法获取内核版本\"; echo -e \"\\n-------- CPU 信息 --------\" && command -v lscpu >/dev/null 2>&1 && lscpu || echo \"无法获取CPU信息\"; echo -e \"\\n-------- 内存信息 --------\" && free -h || echo \"无法获取内存信息\"; echo -e \"\\n-------- 磁盘信息 --------\" && lsblk || echo \"无法获取磁盘信息\"; echo -e \"\\n-------- 磁盘空间 --------\" && df -h || echo \"无法获取磁盘空间信息\"; echo -e \"\\n-------- 网络信息 --------\" && ip a || echo \"无法获取网络信息\"; echo -e \"\\n-------- 系统负载 --------\" && uptime || echo \"无法获取系统负载\"; echo -e \"\\n------ 网络连通测试 ------\" && ping -c 3 baidu.com || echo \"无法连接到 baidu.com\"",
+    "description": "一键查询linux系统的信息"
   }
 ]


### PR DESCRIPTION
添加了一条 shell 脚本命令到内置命令列表:
```shell
echo -e "\n\n------ 操作系统类型 ------" && uname -a || echo "无法获取操作系统信息";
echo -e "\n------ 发行版本信息 ------" && command -v lsb_release >/dev/null 2>&1 && lsb_release -a || echo "无法获取发行版本信息";
echo -e "\n------ 系统详细版本 ------" && [ -f /etc/os-release ] && cat /etc/os-release || echo "无法读取 /etc/os-release 文件";
echo -e "\n------ 系统初始进程 ------" && ps -p 1 -o comm= || echo "无法获取系统初始进程";
echo -e "\n-------- 内核版本 --------" && uname -r || echo "无法获取内核版本";
echo -e "\n-------- CPU 信息 --------" && command -v lscpu >/dev/null 2>&1 && lscpu || echo "无法获取CPU信息";
echo -e "\n-------- 内存信息 --------" && free -h || echo "无法获取内存信息";
echo -e "\n-------- 磁盘信息 --------" && lsblk || echo "无法获取磁盘信息";
echo -e "\n-------- 磁盘空间 --------" && df -h || echo "无法获取磁盘空间信息";
echo -e "\n-------- 网络信息 --------" && ip a || echo "无法获取网络信息";
echo -e "\n-------- 系统负载 --------" && uptime || echo "无法获取系统负载";
echo -e "\n------ 网络连通测试 ------" && ping -c 3 baidu.com || echo "无法连接到 baidu.com"
```

全部使用系统内置命令（但某些极精简的环境可能不包含），  
用于一键显示系统的各种信息，包括操作系统类型、发行版本、内核版本、初始进程、CPU 信息、内存信息、磁盘信息、网络信息、系统负载，  
并进行网络连通性测试，`ping baidu.com` 3次。

已在：
Ubuntu 18.04、Ubuntu 20.04、Ubuntu 22.04、Ubuntu 24.04、  
Alpine 3.19.7、  
CentOS 7、CentOS 8、  
Debian 11、Debian 12、  
Arch Linux (20250406.0.331908)  
中测试这段 shell 脚本（部分通过 GitHub Actions），均没有发生问题。
