### PR TITLE
feat(user-plus): 折叠展示已授权IP，超出5个时可展开/收起

### DIFF
--- a/web/src/views/setting/components/user-plus.vue
+++ b/web/src/views/setting/components/user-plus.vue
@@ -60,13 +60,22 @@
         <span class="label">已授权IP:</span>
         <div class="ip_tags">
           <el-tag
-            v-for="ip in plusInfo.usedIPs"
+            v-for="ip in displayedIPs"
             :key="ip"
             size="small"
             class="ip_tag"
           >
             {{ ip }}
           </el-tag>
+          <el-button
+            v-if="plusInfo.usedIPs.length > 5"
+            link
+            type="primary"
+            class="toggle_ips"
+            @click="showAllIPs = !showAllIPs"
+          >
+            {{ showAllIPs ? '收起' : `+${plusInfo.usedIPs.length - 5} 更多` }}
+          </el-button>
         </div>
       </div>
     </div>
@@ -156,6 +165,13 @@ onMounted(() => {
   getPlusConf()
   getPlusDiscount()
 })
+
+const showAllIPs = ref(false)
+
+const displayedIPs = computed(() => {
+  const ips = plusInfo.value.usedIPs || []
+  return showAllIPs.value ? ips : ips.slice(0, 5)
+})
 </script>
 
 <style lang="scss" scoped>
@@ -228,6 +244,12 @@ onMounted(() => {
 
           .ip_tag {
             margin: 2px;
+          }
+          .toggle_ips {
+            margin-top: 5px;
+            font-size: 12px;
+            padding: 0;
+            height: auto;
           }
         }
       }


### PR DESCRIPTION
为 `web/src/views/setting/components/user-plus.vue` 增加了一个新功能，  
在“已授权IP”展示数超过5个时启用折叠，可点击 `+N 更多` 以展开，点击 `收起` 以折叠。如下图。

---

折叠时：
![截图 2025-05-26 12-42-19](https://github.com/user-attachments/assets/ab9880ff-5fea-4afc-b798-3c98ca4b2c4c)

展开时：
![截图 2025-05-26 12-43-19](https://github.com/user-attachments/assets/a2bace07-3682-41fc-991d-ddc45113ee9a)

---

抱歉水平有限，对样式设计一窍不通，欢迎指出/修改问题，  
或仅当成是一个功能的提议。
