### PR TITLE
feat(terminal): 为终端链接跳转修饰键添加切换设置

### DIFF
--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -39,7 +39,8 @@ const useStore = defineStore('global', {
         themeName: 'Afterglow',
         background: 'linear-gradient(-225deg, #CBBACC 0%, #2580B3 100%)',
         autoReconnect: true,
-        autoExecuteScript: false
+        autoExecuteScript: false,
+        requireModifierForWebLinks: true
       },
       ...(localStorage.getItem('terminalConfig') ? JSON.parse(localStorage.getItem('terminalConfig')) : {})
     },

--- a/web/src/views/terminal/components/terminal-setting.vue
+++ b/web/src/views/terminal/components/terminal-setting.vue
@@ -98,6 +98,22 @@
               />
             </el-tooltip>
           </el-form-item>
+          <el-form-item label="跳转修饰键" prop="requireModifierForWebLinks">
+            <el-tooltip
+              effect="dark"
+              content="禁用后直接点击链接即可跳转(无需Ctrl或Alt键)"
+              placement="right"
+            >
+              <el-switch
+                v-model="requireModifierForWebLinks"
+                class="swtich"
+                inline-prompt
+                style="--el-switch-on-color: #13ce66; --el-switch-off-color: #ff4949"
+                active-text="启用"
+                inactive-text="禁用"
+              />
+            </el-tooltip>
+          </el-form-item>
         </el-form>
       </el-tab-pane>
       <el-tab-pane label="菜单选项">
@@ -181,6 +197,10 @@ const autoExecuteScript = computed({
   get: () => $store.terminalConfig.autoExecuteScript,
   set: (newVal) => $store.setTerminalSetting({ autoExecuteScript: newVal })
 })
+const requireModifierForWebLinks = computed({
+  get: () => $store.terminalConfig.requireModifierForWebLinks,
+  set: (newVal) => $store.setTerminalSetting({ requireModifierForWebLinks: newVal })
+});
 const scriptLibrary = computed({
   get: () => $store.menuSetting.scriptLibrary,
   set: (newVal) => $store.setMenuSetting({ scriptLibrary: newVal })

--- a/web/src/views/terminal/components/terminal-tab.vue
+++ b/web/src/views/terminal/components/terminal-tab.vue
@@ -292,8 +292,13 @@ const handleResize = () => {
 
 const onWebLinks = () => {
   term.value.loadAddon(new WebLinksAddon((event, uri) => {
-    if (event.ctrlKey || event.altKey) window.open(uri, '_blank')
-  }))
+    const requireModifier = $store.terminalConfig.requireModifierForWebLinks;
+    // 根据配置决定跳转行为
+    // 如果用户禁用跳转修饰键，即requireModifier为false则直接跳转
+    if (!requireModifier || event.ctrlKey || event.altKey) {
+      window.open(uri, '_blank');
+    }
+  }));
 }
 
 // :TODO: 重写终端搜索功能


### PR DESCRIPTION
在终端页面的 `功能项` => `本地设置` => `快捷操作` 中新增了一个设置选项：“跳转修饰键”，  
用于控制在终端中点击链接时是否需要按住修饰键才能跳转，默认为启用，即 `true`。

![image](https://github.com/user-attachments/assets/0f5799a7-1dd3-494b-9edf-f17182b1108a)

---

和上一条拉取请求一样我还是不太会设计，不好意思，  
我觉得在这次修改中我对设置项的描述不是很恰当，谢谢理解。
