### PR TITLE
feat(scripts): 脚本库页仅在“内置脚本”分组显示描述列

### DIFF
--- a/web/src/views/scripts/index.vue
+++ b/web/src/views/scripts/index.vue
@@ -66,7 +66,7 @@
           />
           <el-table-column prop="index" label="序号" width="100px" />
           <el-table-column prop="name" label="名称" />
-          <el-table-column prop="description" label="描述" />
+          <el-table-column v-if="group.id === 'builtin'" prop="description" label="描述" />
           <el-table-column prop="command" label="指令内容" show-overflow-tooltip />
           <el-table-column label="操作" fixed="right" width="160px">
             <template #default="{ row }">


### PR DESCRIPTION
https://github.com/chaos-zhu/easynode/issues/178  
使用条件渲染，  
只有当分组 `group.id` 为 `builtin` 时才会显示“描述“列
