### PR TITLE
支持自定义客户端真实IP请求头、向Socket统一对齐客户端IP获取逻辑

### DIFF
--- a/server/.env.template
+++ b/server/.env.template
@@ -4,3 +4,5 @@ DEBUG=1
 # 访问IP限制
 allowedIPs=127.0.0.1,192.168,255.
 
+# 客户端真实IP请求头
+clientIPHeader=x-forwarded-for

--- a/server/app/config/index.js
+++ b/server/app/config/index.js
@@ -1,6 +1,7 @@
 const path = require('path')
 
 consola.info('debug日志：', process.env.DEBUG === '1' ? '开启' : '关闭')
+consola.info('自定义真实IP请求头：', process.env.clientIPHeader ? '是' : '否')
 
 module.exports = {
   httpPort: 8082,
@@ -25,5 +26,6 @@ module.exports = {
   logConfig: {
     outDir: path.join(process.cwd(),'./app/db/logs'),
     recordLog: process.env.DEBUG === '1' // 是否记录日志
-  }
+  },
+  clientIPHeader: process.env.clientIPHeader || 'x-forwarded-for' // 自定义真实IP请求头, 默认为兼容nginx反代
 }

--- a/server/app/middlewares/auth.js
+++ b/server/app/middlewares/auth.js
@@ -1,4 +1,4 @@
-const { apiPrefix } = require('../config')
+const { apiPrefix, clientIPHeader } = require('../config')
 const { verifyAuthSync } = require('../utils/verify-auth')
 
 let whitePath = [
@@ -8,12 +8,15 @@ let whitePath = [
 consola.info('路由白名单：', whitePath)
 
 const useAuth = async ({ request, res }, next) => {
-  const { path, headers: { token } } = request
+  const { path, headers } = request
+  const token = headers.token
+  // 前者为自定义真实IP请求头或默认兼容nginx反代, 后者为中间件获取的IP地址
+  const requestIP = headers[clientIPHeader] || request.ip
   consola.info('verify path: ', path)
   if (whitePath.includes(path)) return next()
   if (!token) return res.fail({ msg: '未登录', status: 403 })
   // 验证token
-  const { code, msg } = await verifyAuthSync(token, request.ip)
+  const { code, msg } = await verifyAuthSync(token, requestIP)
   switch (code) {
     case 1:
       return await next()

--- a/server/app/middlewares/ipFilter.js
+++ b/server/app/middlewares/ipFilter.js
@@ -1,13 +1,17 @@
 // 白名单IP
 const fs = require('fs')
 const path = require('path')
+const { clientIPHeader } = require('../config')
 const { isAllowedIp } = require('../utils/tools')
 
 const htmlPath = path.join(__dirname, '../template/ipForbidden.html')
 const ipForbiddenHtml = fs.readFileSync(htmlPath, 'utf8')
 
 const ipFilter = async (ctx, next) => {
-  if (isAllowedIp(ctx.request.ip)) return await next()
+  // 前者为自定义真实IP请求头或默认兼容nginx反代, 后者为中间件获取的IP地址
+  const requestIP = ctx.request.headers[clientIPHeader] || ctx.request.ip
+
+  if (isAllowedIp(requestIP)) return await next()
   ctx.status = 403
   ctx.body = ipForbiddenHtml
 }

--- a/server/app/socket/clients.js
+++ b/server/app/socket/clients.js
@@ -1,6 +1,6 @@
 const { Server: ServerIO } = require('socket.io')
 const { io: ClientIO } = require('socket.io-client')
-const { defaultClientPort } = require('../config')
+const { defaultClientPort, clientIPHeader } = require('../config')
 const { verifyAuthSync } = require('../utils/verify-auth')
 const { isAllowedIp } = require('../utils/tools')
 const { HostListDB } = require('../utils/db-class')
@@ -70,8 +70,8 @@ module.exports = (httpServer) => {
   })
 
   serverIo.on('connection', (socket) => {
-    // 前者兼容nginx反代, 后者兼容nodejs自身服务
-    let requestIP = socket.handshake.headers['x-forwarded-for'] || socket.handshake.address
+    // 前者为自定义真实IP请求头或默认兼容nginx反代, 后者兼容nodejs自身服务
+    let requestIP = socket.handshake.headers[clientIPHeader] || socket.handshake.address
     if (!isAllowedIp(requestIP)) {
       socket.emit('ip_forbidden', 'IP地址不在白名单中')
       socket.disconnect()

--- a/server/app/socket/docker.js
+++ b/server/app/socket/docker.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const { Server } = require('socket.io')
 const { Client: SSHClient } = require('ssh2')
+const { clientIPHeader } = require('../config')
 const { verifyAuthSync } = require('../utils/verify-auth')
 const { isAllowedIp } = require('../utils/tools')
 const { createTerminal } = require('./terminal')
@@ -19,7 +20,7 @@ module.exports = (httpServer) => {
   serverIo.on('connection', (socket) => {
     connectionCount++
     consola.success(`docker websocket 已连接 - 当前连接数: ${ connectionCount }`)
-    let requestIP = socket.handshake.headers['x-forwarded-for'] || socket.handshake.address
+    let requestIP = socket.handshake.headers[clientIPHeader] || socket.handshake.address
     if (!isAllowedIp(requestIP)) {
       socket.emit('ip_forbidden', 'IP地址不在白名单中')
       socket.disconnect()

--- a/server/app/socket/onekey.js
+++ b/server/app/socket/onekey.js
@@ -1,5 +1,6 @@
 const { Server } = require('socket.io')
 const { Client: SSHClient } = require('ssh2')
+const { clientIPHeader } = require('../config')
 const { sendNoticeAsync } = require('../utils/notify')
 const { verifyAuthSync } = require('../utils/verify-auth')
 const { shellThrottle } = require('../utils/tools')
@@ -93,8 +94,8 @@ module.exports = (httpServer) => {
     }
   })
   serverIo.on('connection', (socket) => {
-    // 前者兼容nginx反代, 后者兼容nodejs自身服务
-    let requestIP = socket.handshake.headers['x-forwarded-for'] || socket.handshake.address
+    // 前者为自定义真实IP请求头或默认兼容nginx反代, 后者兼容nodejs自身服务
+    let requestIP = socket.handshake.headers[clientIPHeader] || socket.handshake.address
     if (!isAllowedIp(requestIP)) {
       socket.emit('ip_forbidden', 'IP地址不在白名单中')
       socket.disconnect()

--- a/server/app/socket/sftp.js
+++ b/server/app/socket/sftp.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra')
 const SFTPClient = require('ssh2-sftp-client')
 const CryptoJS = require('crypto-js')
 const { Server } = require('socket.io')
-const { sftpCacheDir } = require('../config')
+const { sftpCacheDir, clientIPHeader } = require('../config')
 const { verifyAuthSync } = require('../utils/verify-auth')
 const { isAllowedIp } = require('../utils/tools')
 const { HostListDB } = require('../utils/db-class')
@@ -227,8 +227,8 @@ module.exports = (httpServer) => {
     }
   })
   serverIo.on('connection', (socket) => {
-    // 前者兼容nginx反代, 后者兼容nodejs自身服务
-    let requestIP = socket.handshake.headers['x-forwarded-for'] || socket.handshake.address
+    // 前者为自定义真实IP请求头或默认兼容nginx反代, 后者兼容nodejs自身服务
+    let requestIP = socket.handshake.headers[clientIPHeader] || socket.handshake.address
     if (!isAllowedIp(requestIP)) {
       socket.emit('ip_forbidden', 'IP地址不在白名单中')
       socket.disconnect()

--- a/server/app/socket/terminal.js
+++ b/server/app/socket/terminal.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const { Server } = require('socket.io')
 const { Client: SSHClient } = require('ssh2')
+const { clientIPHeader } = require('../config')
 const { verifyAuthSync } = require('../utils/verify-auth')
 const { sendNoticeAsync } = require('../utils/notify')
 const { isAllowedIp, ping } = require('../utils/tools')
@@ -123,7 +124,7 @@ module.exports = (httpServer) => {
   serverIo.on('connection', (socket) => {
     connectionCount++
     consola.success(`terminal websocket 已连接 - 当前连接数: ${ connectionCount }`)
-    let requestIP = socket.handshake.headers['x-forwarded-for'] || socket.handshake.address
+    let requestIP = socket.handshake.headers[clientIPHeader] || socket.handshake.address
     if (!isAllowedIp(requestIP)) {
       socket.emit('ip_forbidden', 'IP地址不在白名单中')
       socket.disconnect()


### PR DESCRIPTION
1. 新增了功能，可以通过环境变量来自定义客户端真实 IP 请求头，以控制程序该读取哪个请求头作为客户端 IP，  
   默认使用 `x-forwarded-for`，以及默认回退使用 NodeJS 兼容方法获取客户端 IP。
2. 修改 `server/app/controller/user.js`、`server/app/middlewares/auth.js`、`server/app/middlewares/ipFilter.js` 这三个文件的相关获取客户端 IP 的方法，向 `server/app/socket/` 下的文件同步。

---

此前我创建了这个 issues，之后我关闭了因为觉得似乎没必要，现在又认为这似乎是一个合理的需求：  
[考虑支持自定义从 HTTP Header 中获取真实IP吗？] #144

---

然而我并不确定我找到了所有与 Socket 有不同获取客户端 IP 逻辑的文件并修改，请注意一下，谢谢！  
Closes #181
