### PR TITLE
解决在非全屏模式下，脚本编辑器中的编码模式选项无法显示的问题

### DIFF
--- a/web/src/views/terminal/components/script-input.vue
+++ b/web/src/views/terminal/components/script-input.vue
@@ -95,23 +95,15 @@
 
         <!-- 脚本编辑器中的脚本编码模式选项 -->
         <div class="execution_mode_selector">
-          <el-tooltip placement="top">
-            <template #content>
-              <div style="max-width: 300px;">
-                <strong>直接发送：</strong>适用于单行简单脚本，内容直接发送到终端<br><br>
-                <strong>Base64编码：</strong>适用于多行复杂脚本，通过Base64编码后发送，可避免特殊字符转义、heredoc标记冲突等问题
-              </div>
-            </template>
-            <el-select
-              v-model="editorUseBase64"
-              size="small"
-              style="width: 100px;"
-              :teleported="false"
-            >
-              <el-option :value="false" label="直接发送" />
-              <el-option :value="true" label="Base64编码" />
-            </el-select>
-          </el-tooltip>
+          <el-select
+            v-model="editorUseBase64"
+            size="small"
+            style="width: 100px;"
+            :teleported="false"
+          >
+            <el-option :value="false" label="直接发送" />
+            <el-option :value="true" label="Base64编码" />
+          </el-select>
         </div>
         <div class="action_btn">
           <el-dropdown


### PR DESCRIPTION
发现之前的修改引入了一个新的bug，全屏模式下脚本编辑器中的编码模式选项（el-select）是可以正常显示的，但是非全屏状态选项没有显示，因为设置了:teleported="false"，el-select没有被正确地teleport到body中，移除el-select所在的上一层级的tooltip包裹则可以修复
<img width="881" height="224" alt="image" src="https://github.com/user-attachments/assets/59254a3d-7aee-41c9-90ef-f6a93dfe3cdd" />
